### PR TITLE
Admin proofs 

### DIFF
--- a/.adminbro/.entry.js
+++ b/.adminbro/.entry.js
@@ -1,1 +1,3 @@
 AdminBro.UserComponents = {}
+import Component1 from '../admin/view-proof-documents.component'
+AdminBro.UserComponents.Component1 = Component1

--- a/admin/view-proof-documents.component.jsx
+++ b/admin/view-proof-documents.component.jsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { Box } from 'admin-bro'
+
+const Dashboard = (props) => {
+    console.log('props', props);
+    return (
+        <Box>
+            <Documents docs={props.record.params.documents} />
+        </Box>
+    )
+}
+class Document extends React.Component {
+    render() {
+        return (
+            <li >
+                <a href={this.props.document.uri} target="_blank">{this.props.document.uri}</a>
+            </li>
+        )
+    }
+}
+class Documents extends React.Component {
+    generateLinks() {
+        let container = [];
+        for (let d of this.props.docs) {
+            container.push(
+                <Document key={d.id} document={d} />
+            )
+        }
+        return container;
+    }
+    render() {
+        return (
+            <ul>
+                {this.generateLinks()}
+            </ul>
+        );
+    }
+}
+
+export default Dashboard

--- a/admin/view-proof-documents.component.jsx
+++ b/admin/view-proof-documents.component.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import { Box } from 'admin-bro'
 
-const Dashboard = (props) => {
+const Panel = (props) => {
     console.log('props', props);
     return (
         <Box>
-            <Documents docs={props.record.params.documents} />
+            <Documents documents={props.record.populated.documents} />
         </Box>
     )
 }
@@ -21,9 +21,9 @@ class Document extends React.Component {
 class Documents extends React.Component {
     generateLinks() {
         let container = [];
-        for (let d of this.props.docs) {
+        for (let d of this.props.documents) {
             container.push(
-                <Document key={d.id} document={d} />
+                <Document key={d.params.id} document={d.params} />
             )
         }
         return container;
@@ -37,4 +37,4 @@ class Documents extends React.Component {
     }
 }
 
-export default Dashboard
+export default Panel

--- a/admin/view-proof-documents.component.jsx
+++ b/admin/view-proof-documents.component.jsx
@@ -3,6 +3,9 @@ import { Box } from 'admin-bro'
 
 const Panel = (props) => {
     console.log('props', props);
+    if(props.record.populated.documents === undefined){
+        window.location.reload(false);
+    }
     return (
         <Box>
             <Documents documents={props.record.populated.documents} />

--- a/app.js
+++ b/app.js
@@ -16,8 +16,7 @@ const models = require('./models');
 AdminBro.registerAdapter(AdminBroSequelize);
 
 const generateSecret = function () {
-  // return '' + Math.random() + Math.random() + Math.random();
-  return 'hello'
+  return '' + Math.random() + Math.random() + Math.random();
 }
 
 let adminBro = new AdminBro({
@@ -60,12 +59,17 @@ let adminBro = new AdminBro({
           isAccessible: true,
           handler: async (req, res, context) => {
             let proof = context.record;
+            const DocumentResource = context._admin.findResource('Documents')
             const docs = await models.Document.findAll({ where: { ProofId: proof.params.id } });
-            proof.params.documents = docs;
-            console.log(proof);
+            const documentRecords = await DocumentResource.findMany(docs.map(it => it.id));
+            proof.populate('documents', {
+              records: documentRecords,
+              toJSON: function() {
+                return this.records.map(it => it.toJSON());
+              }
+            });
             return {
-              record: await proof.toJSON()
-
+              record: proof.toJSON()
             }
           },
           component: AdminBro.bundle('./admin/view-proof-documents.component.jsx'),

--- a/app.js
+++ b/app.js
@@ -15,82 +15,108 @@ const argon2 = require('argon2');
 const models = require('./models');
 AdminBro.registerAdapter(AdminBroSequelize);
 
-const generateSecret = function(){
-  return ''+Math.random()+Math.random()+Math.random();
+const generateSecret = function () {
+  // return '' + Math.random() + Math.random() + Math.random();
+  return 'hello'
 }
 
 let adminBro = new AdminBro({
-    databases: [models],
-    rootPath: '/admin',
-    branding: {
-        companyName: 'COVID-19 PPE Tracker'
-    },
-    resources: [{
-        resource: models.User,
-        options: {
-            properties: {
-                password: {
-                    type: 'string',
-                    isVisible: {
-                        list: false, edit: true, filter: false, show: false,
-                    }
-                },
-            },
-            actions: {
-                new: {
-                    before: async (request) => {
-                        if (request.payload.password) {
-                            request.payload.password = await argon2.hash(request.payload.password);
-                        }
-                        return request;
-                    },
-                }
+  databases: [models],
+  rootPath: '/admin',
+  branding: {
+    companyName: 'COVID-19 PPE Tracker'
+  },
+  resources: [{
+    resource: models.User,
+    options: {
+      properties: {
+        password: {
+          type: 'string',
+          isVisible: {
+            list: false, edit: true, filter: false, show: false,
+          },
+        },
+      },
+      actions: {
+        new: {
+          before: async (request) => {
+            if (request.payload.password) {
+              request.payload.password = await argon2.hash(request.payload.password);
             }
+            return request;
+          },
         }
-    }],
+      }
+    }
+  },
+  {
+    resource: models.Proof,
+    options: {
+      actions: {
+        documents: {
+          actionType: 'record',
+          icon: 'View',
+          isVisible: true,
+          isAccessible: true,
+          handler: async (req, res, context) => {
+            let proof = context.record;
+            const docs = await models.Document.findAll({ where: { ProofId: proof.params.id } });
+            proof.params.documents = docs;
+            console.log(proof);
+            return {
+              record: await proof.toJSON()
+
+            }
+          },
+          component: AdminBro.bundle('./admin/view-proof-documents.component.jsx'),
+        },
+      },
+    },
+  }
+  ],
 });
 
 const router = AdminBroExpress.buildAuthenticatedRouter(adminBro, {
-    authenticate: async (email, password) => {
-        const user = await models.User.findOne({ 
-            where: {
-                email,
-                role:'admin'
-            }
-        });
-        if (user) {
-            const matched = await argon2.verify(user.dataValues.password, password);
-            if (matched) {
-                return user;
-            }
-        }
-        return false;
-    },
-    cookiePassword: generateSecret(),
+  authenticate: async (email, password) => {
+    const user = await models.User.findOne({
+      where: {
+        email,
+        role: 'admin'
+      }
+    });
+    if (user) {
+      const matched = await argon2.verify(user.dataValues.password, password);
+      if (matched) {
+        return user;
+      }
+    }
+    return false;
+  },
+  cookiePassword: generateSecret(),
 })
 
 // const router = AdminBroExpress.buildRouter(adminBro)
 
 const vapidKeys = {
-    publicKey: fs.readFileSync("./server.pub").toString(),
-    privateKey: fs.readFileSync('./server.priv').toString()
+  publicKey: fs.readFileSync("./server.pub").toString(),
+  privateKey: fs.readFileSync('./server.priv').toString()
 };
 
 webpush.setVapidDetails(
-    'mailto:web-push-book@gauntface.com',
-    vapidKeys.publicKey,
-    vapidKeys.privateKey
+  'mailto:web-push-book@gauntface.com',
+  vapidKeys.publicKey,
+  vapidKeys.privateKey
 );
 var app = express();
 let sess = {
-    secret: generateSecret(),
-    resave: false,
-    saveUninitialized: true,
-    cookie: {}
+  secret: generateSecret(),
+  resave: false,
+  saveUninitialized: true,
+  cookie: {}
 }
 
 if (app.get('env') === 'production') {
-  app.set('trust proxy', 1) ;
+  app.set('trust proxy', 1);
   sess.cookie.secure = true;
 }
 


### PR DESCRIPTION
Adds a new action to Proof in AdminBro to view the list of Documents uploaded ( Closes issue #16 )

The link to view documents can be accessed either through the List Proofs page like this:
![Screenshot from 2020-04-12 20-21-27](https://user-images.githubusercontent.com/7351026/79071879-9bc16600-7cfb-11ea-9aec-5017d2c67377.png)

or via the View Proof page:
![Screenshot from 2020-04-12 20-21-32](https://user-images.githubusercontent.com/7351026/79071887-a419a100-7cfb-11ea-9c30-bd87de957e27.png)

The resulting page lists the document links:
![Screenshot from 2020-04-12 20-22-04](https://user-images.githubusercontent.com/7351026/79071893-b09df980-7cfb-11ea-85d8-35a0f940b433.png)
